### PR TITLE
Add wget to build-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,7 +50,7 @@ apps:
 parts:
   mysql-server:
     prepare: ./stage_binaries.sh
-    build-packages: [libaio-dev, libmecab-dev, libnuma-dev, libncurses5-dev, zlib1g-dev]
+    build-packages: [libaio-dev, libmecab-dev, libnuma-dev, libncurses5-dev, wget, zlib1g-dev]
     plugin: dump
     source: ./
     organize:


### PR DESCRIPTION
For building on systems that don't have wget installed, like docker.