### PR TITLE
Add wget to build-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,6 +50,7 @@ apps:
 parts:
   mysql-server:
     prepare: ./stage_binaries.sh
+    build-packages: [wget]
     plugin: dump
     source: ./
     organize:


### PR DESCRIPTION
For building on systems that don't have wget installed, like docker.